### PR TITLE
Filter unit tests on "Unit" regex and output test coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: test-unit
 
 .PHONY: test-unit
 test-unit: test-deps
-	go test ./...
+	go test ./... -run 'Unit' -coverprofile=coverage.out
 
 .PHONY: clean
 clean:

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -88,7 +88,7 @@ func (m MockConsumer) Errors() <-chan error {
 	return nil
 }
 
-func TestStart(t *testing.T) {
+func TestUnitStart(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
Filter tests by checking the regex "Unit" against the test name to prevent integration tests running and output the test coverage for use with Sonar.