### PR TITLE
Use DOCKER_BUILDKIT=0 flag for Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Consumer to allow for reconciliation of payments
 Pull image from private CH registry by running `docker pull 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payment-reconciliation-consumer:latest` command or run the following steps to build image locally:
 
 1. `export SSH_PRIVATE_KEY_PASSPHRASE='[your SSH key passhprase goes here]'` (optional, set only if SSH key is passphrase protected)
-2. `docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payment-reconciliation-consumer:latest .`
+2. `DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE -t 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payment-reconciliation-consumer:latest .`


### PR DESCRIPTION
Docker releases >=2.4.0.0 have BuildKit enabled by default - this breaks image builds due to a known issue (https://github.com/moby/buildkit/issues/816) with BuildKit and ONBUILD COPY --from directives which we use in our runtime image.

Prefixing `docker build` commands with `DOCKER_BUILDKIT=0` fixes the issue