### PR TITLE
Add logic to skip payment resources which return a 410 Gone status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # payment-reconciliation-consumer
 Consumer to allow for reconciliation of payments
 
+## Handling 410 (Gone) Resources
+The `payment-reconciliation-consumer` contains handling for situations where a 410 (Gone) status code is returned by the Payments API - with three scenarios available:
+
+* Skip all messages where a 410 (Gone) status code is received
+* Do not skip any messages where a 410 (Gone) status code is received
+* Only skip messages which relate to a given payment ID, where a 410 (Gone) status code is received
+
+These scenarios can be configured via the `SKIP_GONE_RESOURCE` and `SKIP_GONE_RESOURCE_ID` environment variables with the following configurations.
+
+* `SKIP_GONE_RESOURCE=true` and `SKIP_GONE_RESOURCE_ID` is unset - skip all messages.
+* `SKIP_GONE_RESOURCE=false` - do not skip any messages - the value of `SKIP_GONE_RESOURCE_ID` is ignored if one is set.
+* `SKIP_GONE_RESOURCE=true` and `SKIP_GONE_RESOURCE_ID=<payment_id>` - only skip messages which receive a 410 gone and match the given payment id.
+
+
 ## Docker support
 
 Pull image from private CH registry by running `docker pull 169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/payment-reconciliation-consumer:latest` command or run the following steps to build image locally:

--- a/config/config.go
+++ b/config/config.go
@@ -33,16 +33,6 @@ type ProductMap struct {
 	Codes map[string]int `yaml:"product_code"`
 }
 
-// ServiceConfig returns a ServiceConfig interface for Config
-func (c Config) ServiceConfig() ServiceConfig {
-	return ServiceConfig{c}
-}
-
-// ServiceConfig wraps Config to implement service.Config
-type ServiceConfig struct {
-	Config
-}
-
 // Namespace implements service.Config.Namespace
 func (c *Config) Namespace() string {
 	return "payment-reconciliation-consumer"

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,8 @@ type Config struct {
 	TransactionsCollection         string      `env:"MONGODB_PAYMENT_REC_TRANSACTIONS_COLLECTION"   flag:"mongodb-payment-rec-transactions-collection"  flagDesc:"MongoDB collection for payment transactions data"`
 	ProductsCollection             string      `env:"MONGODB_PAYMENT_REC_PRODUCTS_COLLECTION"       flag:"mongodb-payment-rec-products-collection"      flagDesc:"MongoDB collection for payment products data"`
 	RefundsCollection              string      `env:"MONGODB_PAYMENT_REC_REFUNDS_COLLECTION"        flag:"mongodb-payment-rec-refunds-collection"       flagDesc:"MongoDB collection for refunds data"`
+	SkipGoneResource          	   bool        `env:"SKIP_GONE_RESOURCE"                            flag:"skip-gone-resource"                           flagDesc:"Boolean which indicates whether messages with resources that return 410 should be skipped"`
+	SkipGoneResourceId        	   string      `env:"SKIP_GONE_RESOURCE_ID"                         flag:"skip-gone-resource-id"                        flagDesc:"Set this if you only want to skip a specific message with a resource returning a 410 - requires SKIP_GONE_RESOURCE=true"`
 }
 
 // ProductMap contains a map of product codes

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Shopify/sarama v1.24.1
 	github.com/bsm/sarama-cluster v2.1.15+incompatible // indirect
-	github.com/companieshouse/chs.go v1.2.0
+	github.com/companieshouse/chs.go v1.2.4
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/golang/mock v1.4.4
 	github.com/ian-kent/envconf v0.0.0-20141026121121-c19809918c02 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/bsm/sarama-cluster v2.1.15+incompatible h1:RkV6WiNRnqEEbp81druK8zYhmnIgdOjqSVi0+9Cnl2A=
 github.com/bsm/sarama-cluster v2.1.15+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
-github.com/companieshouse/chs.go v1.1.1 h1:iX+Kp01LSMrW/jVnFCshtmz29jzt9Sj9qqX7eaqYE5U=
-github.com/companieshouse/chs.go v1.1.1/go.mod h1:fI/z3fegJtQyjOWP2HSj+im96Djn399DbckG3Mi1eAo=
-github.com/companieshouse/chs.go v1.2.0 h1:wFE5bcaYESyWdYSqJuQ4pquVubSlJS+WCkS0cfC2Arg=
-github.com/companieshouse/chs.go v1.2.0/go.mod h1:fI/z3fegJtQyjOWP2HSj+im96Djn399DbckG3Mi1eAo=
+github.com/companieshouse/chs.go v1.2.4 h1:zoSAZb9l6JCyX+3F2y2es95Mk7KRexhWNtBd8+q3FxM=
+github.com/companieshouse/chs.go v1.2.4/go.mod h1:93vQ2qlzSbZenUOFet+pAJzxHdz+w6BF1IvJ56lvC7c=
 github.com/companieshouse/htmlform v0.1.0/go.mod h1:fWScPVYjGyeBhYwppGaGRDtCQ5hMd3t3Q+0I6HaUZT4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -95,6 +93,7 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbdyOsSH/XohnWpXOlq9NBD5sGAB2FciQMUEe8=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=


### PR DESCRIPTION
This PR:

* Adds two environment variables: `SKIP_GONE_RESOURCE` and `SKIP_GONE_RESOURCE_ID`
* Injects the env vars into the core `service`
* Bump `chs.go` library to 1.2.4
* Add logging for resilience failures - TODO add failure state for resilience
* Adds unit tests for skip gone resource code
* Updates README