### PR TITLE
Fix is reconcilable check

### DIFF
--- a/data/paymentResponse.go
+++ b/data/paymentResponse.go
@@ -10,6 +10,7 @@ import (
 const DataMaintenance = "data-maintenance"
 const OrderableItem = "orderable-item"
 const Penalty = "penalty"
+const Legacy = "legacy"
 
 // PaymentResponse represents a response from the payment service GET payment endpoint
 type PaymentResponse struct {
@@ -66,8 +67,6 @@ type RefundResource struct {
 
 // Indicates whether the payment is reconcilable or not.
 func (payment PaymentResponse) IsReconcilable(productMap *config.ProductMap) bool {
-	// return (payment.Costs[0].ClassOfPayment[0] == DataMaintenance ||
-	// 	payment.Costs[0].ClassOfPayment[0] == OrderableItem)
 
 	classOfPayment := payment.Costs[0].ClassOfPayment[0]
 

--- a/data/paymentResponse_test.go
+++ b/data/paymentResponse_test.go
@@ -4,34 +4,80 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	. "github.com/stretchr/testify/assert"
 	"testing"
+	"github.com/companieshouse/payment-reconciliation-consumer/config"
+	"github.com/companieshouse/chs.go/log"
+	"fmt"
+	"path/filepath"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
 )
 
 func TestUnitIsReconcilable(t *testing.T) {
 
+	productMap, err := createProductMap()
+
+	if err != nil {
+		log.Error(fmt.Errorf("error initialising productMap: %s", err), nil)
+	}
+
 	Convey("data-maintenance payments are reconcilable", t, func() {
-		dataMaintenance := createPaymentResponse(DataMaintenance)
-		Equal(t, dataMaintenance.IsReconcilable(), true, "data-maintenance payments should be reconcilable")
+		dataMaintenance := createPaymentResponse(DataMaintenance, "ds01")
+		Equal(t, dataMaintenance.IsReconcilable(productMap), true, "data-maintenance payments should be reconcilable")
 	})
 
 	Convey("orderable-item payments are reconcilable", t, func() {
-		orderableItem := createPaymentResponse(OrderableItem)
-		Equal(t, orderableItem.IsReconcilable(), true, "orderable-item payments should be reconcilable")
+		orderableItem := createPaymentResponse(OrderableItem, "certificate")
+		Equal(t, orderableItem.IsReconcilable(productMap), true, "orderable-item payments should be reconcilable")
 	})
 
 	Convey("penalty payments are not reconcilable", t, func() {
-		penalty := createPaymentResponse(Penalty)
-		Equal(t, penalty.IsReconcilable(), false, "penalty payments should not be reconcilable")
+		penalty := createPaymentResponse(Penalty, "lfp")
+		Equal(t, penalty.IsReconcilable(productMap), false, "penalty payments should not be reconcilable")
+	})
+
+	Convey("penalty payments are not reconcilable", t, func() {
+		penalty := createPaymentResponse(Legacy, "webfiling")
+		Equal(t, penalty.IsReconcilable(productMap), false, "legacy payments should not be reconcilable")
+	})
+
+	Convey("penalty payments are not reconcilable", t, func() {
+		penalty := createPaymentResponse(DataMaintenance, "extractives")
+		Equal(t, penalty.IsReconcilable(productMap), false, "extractives payments should not be reconcilable")
 	})
 
 }
 
 // Creates a payment response with the class of payment specified.
-func createPaymentResponse(classOfPayment string) PaymentResponse {
+func createPaymentResponse(classOfPayment string, productType string) PaymentResponse {
 	cost := Cost{
 		ClassOfPayment: []string{classOfPayment},
+		ProductType: productType,
 	}
 	paymentResponse := PaymentResponse{
 		Costs: []Cost{cost},
 	}
 	return paymentResponse
+}
+
+func createProductMap() (*config.ProductMap, error) {
+	var productMap *config.ProductMap
+
+	filename, err := filepath.Abs("../assets/product_code.yml")
+	if err != nil {
+		return nil, err
+	}
+
+	yamlFile, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(yamlFile, &productMap)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("Product map config has been loaded", log.Data{"products": productMap})
+
+	return productMap, nil
 }

--- a/data/paymentResponse_test.go
+++ b/data/paymentResponse_test.go
@@ -35,14 +35,19 @@ func TestUnitIsReconcilable(t *testing.T) {
 		Equal(t, penalty.IsReconcilable(productMap), false, "penalty payments should not be reconcilable")
 	})
 
-	Convey("penalty payments are not reconcilable", t, func() {
+	Convey("legacy payments are not reconcilable", t, func() {
 		penalty := createPaymentResponse(Legacy, "webfiling")
 		Equal(t, penalty.IsReconcilable(productMap), false, "legacy payments should not be reconcilable")
 	})
 
-	Convey("penalty payments are not reconcilable", t, func() {
+	Convey("extractives payments are not reconcilable", t, func() {
 		penalty := createPaymentResponse(DataMaintenance, "extractives")
 		Equal(t, penalty.IsReconcilable(productMap), false, "extractives payments should not be reconcilable")
+	})
+
+	Convey("empty product type payments are not reconcilable", t, func() {
+		penalty := createPaymentResponse(DataMaintenance, "")
+		Equal(t, penalty.IsReconcilable(productMap), false, "empty product type payment should not be reconcilable")
 	})
 
 }

--- a/service/service.go
+++ b/service/service.go
@@ -3,20 +3,21 @@ package service
 import (
 	"errors"
 	"fmt"
-	"github.com/companieshouse/payment-reconciliation-consumer/dao"
-	"github.com/companieshouse/payment-reconciliation-consumer/keys"
-	"github.com/companieshouse/payment-reconciliation-consumer/models"
-	"github.com/companieshouse/payment-reconciliation-consumer/transformer"
 	"net/http"
 	"os"
 	"sync"
 	"time"
 
+	"github.com/companieshouse/payment-reconciliation-consumer/dao"
+	"github.com/companieshouse/payment-reconciliation-consumer/keys"
+	"github.com/companieshouse/payment-reconciliation-consumer/models"
+	"github.com/companieshouse/payment-reconciliation-consumer/transformer"
+
 	"github.com/Shopify/sarama"
 	"github.com/companieshouse/chs.go/avro"
 	"github.com/companieshouse/chs.go/avro/schema"
 	"github.com/companieshouse/chs.go/kafka/client"
-	"github.com/companieshouse/chs.go/kafka/consumer/cluster"
+	consumer "github.com/companieshouse/chs.go/kafka/consumer/cluster"
 	"github.com/companieshouse/chs.go/kafka/producer"
 	"github.com/companieshouse/chs.go/kafka/resilience"
 	"github.com/companieshouse/chs.go/log"
@@ -233,7 +234,7 @@ func (svc *Service) Start(wg *sync.WaitGroup, c chan os.Signal) {
 					log.Info("Payment Response : ",
 						log.Data{keys.PaymentResponse: paymentResponse, keys.StatusCode: statusCode})
 
-					if err == nil && paymentResponse.IsReconcilable() {
+					if err == nil && paymentResponse.IsReconcilable(svc.ProductMap) {
 
 						//Create GetPayment payment URL
 						getPaymentDetailsURL := svc.PaymentsAPIURL + "/private/payments/" + pp.ResourceURI + "/payment-details"

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -552,6 +552,7 @@ func processingOfPaymentKafkaMessageCreatesReconciliationRecords(
 
 			cost := data.Cost{
 				ClassOfPayment: []string{classOfPayment},
+				ProductType: "certificate",
 			}
 
 			pr := data.PaymentResponse{
@@ -626,6 +627,7 @@ func processingOfRefundKafkaMessageCreatesReconciliationRecords(
 
 			cost := data.Cost{
 				ClassOfPayment: []string{classOfPayment},
+				ProductType: "certificate",
 			}
 
 			pr := data.PaymentResponse{
@@ -695,6 +697,7 @@ func processingOfRefundKafkaMessageWithSubmittedStatusCreatesReconciliationRecor
 
 			cost := data.Cost{
 				ClassOfPayment: []string{classOfPayment},
+				ProductType: "certificate",
 			}
 
 			pr := data.PaymentResponse{
@@ -776,6 +779,7 @@ func processingOfRefundKafkaMessageWithMultipleRefundsCreatesReconciliationRecor
 
 			cost := data.Cost{
 				ClassOfPayment: []string{classOfPayment},
+				ProductType: "certificate",
 			}
 
 			pr := data.PaymentResponse{
@@ -855,6 +859,7 @@ func processingOfUnsuccessfulRefundKafkaMessageWithIncorrectRefundIdDoesNotCreat
 
 			cost := data.Cost{
 				ClassOfPayment: []string{classOfPayment},
+				ProductType: "certificate",
 			}
 
 			pr := data.PaymentResponse{
@@ -923,6 +928,7 @@ func processingOfUnsuccessfulRefundKafkaMessageDoesNotCreateReconciliationRecord
 
 			cost := data.Cost{
 				ClassOfPayment: []string{classOfPayment},
+				ProductType: "certificate",
 			}
 
 			pr := data.PaymentResponse{
@@ -991,6 +997,7 @@ func processingOfUnsuccessfulRefundKafkaMessageWithSubmittedDoesNotCreateReconci
 
 			cost := data.Cost{
 				ClassOfPayment: []string{classOfPayment},
+				ProductType: "certificate",
 			}
 
 			pr := data.PaymentResponse{


### PR DESCRIPTION
This pr changes the is reconcilable check for payments so that payments reconciled elsewhere are not reconciled by the payment reconciler. This includes legacy and extractives payments. Payments are filtered on class and product type.

**Resolves:**
- NCPP-146