### PR TITLE
Use correct types for specific log.data keys & add unit test for refund

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/Shopify/sarama v1.24.1
 	github.com/bsm/sarama-cluster v2.1.15+incompatible // indirect
-	github.com/companieshouse/chs.go v1.2.4
+	github.com/companieshouse/chs.go v1.2.8
 	github.com/golang/mock v1.4.4
 	github.com/ian-kent/envconf v0.0.0-20141026121121-c19809918c02 // indirect
 	github.com/ian-kent/gofigure v0.0.0-20170502192241-c9dc3a1359af

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWso
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
 github.com/bsm/sarama-cluster v2.1.15+incompatible h1:RkV6WiNRnqEEbp81druK8zYhmnIgdOjqSVi0+9Cnl2A=
 github.com/bsm/sarama-cluster v2.1.15+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
-github.com/companieshouse/chs.go v1.2.4 h1:zoSAZb9l6JCyX+3F2y2es95Mk7KRexhWNtBd8+q3FxM=
-github.com/companieshouse/chs.go v1.2.4/go.mod h1:93vQ2qlzSbZenUOFet+pAJzxHdz+w6BF1IvJ56lvC7c=
+github.com/companieshouse/chs.go v1.2.8 h1:HY2Wgd9MIKSaFplZ6FvQ+LdLoKrt53mikP8Kvmmk5X0=
+github.com/companieshouse/chs.go v1.2.8/go.mod h1:93vQ2qlzSbZenUOFet+pAJzxHdz+w6BF1IvJ56lvC7c=
 github.com/companieshouse/htmlform v0.1.0/go.mod h1:fWScPVYjGyeBhYwppGaGRDtCQ5hMd3t3Q+0I6HaUZT4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/payment/payment.go
+++ b/payment/payment.go
@@ -68,7 +68,6 @@ func (impl *Fetch) GetPayment(paymentAPIURL string, HTTPClient *http.Client, api
 	}
 
 	body, err := ioutil.ReadAll(res.Body)
-	log.Info("Payment response body", log.Data{keys.Payment: string(body)})
 	if err != nil {
 		return p, res.StatusCode, err
 	}
@@ -76,6 +75,7 @@ func (impl *Fetch) GetPayment(paymentAPIURL string, HTTPClient *http.Client, api
 	if err := json.Unmarshal(body, &p); err != nil {
 		return p, res.StatusCode, err
 	}
+	log.Info("Payment response body", log.Data{keys.Payment: p})
 
 	return p, res.StatusCode, nil
 }
@@ -104,7 +104,6 @@ func (impl *Fetch) GetPaymentDetails(paymentAPIURL string, HTTPClient *http.Clie
 	}
 
 	body, err := ioutil.ReadAll(res.Body)
-	log.Info("Payment details response body", log.Data{keys.PaymentDetails: string(body)})
 	if err != nil {
 		return p, res.StatusCode, err
 	}
@@ -112,6 +111,7 @@ func (impl *Fetch) GetPaymentDetails(paymentAPIURL string, HTTPClient *http.Clie
 	if err := json.Unmarshal(body, &p); err != nil {
 		return p, res.StatusCode, err
 	}
+	log.Info("Payment details response body", log.Data{keys.PaymentDetails: p})
 
 	return p, res.StatusCode, nil
 }
@@ -139,7 +139,6 @@ func (impl *Fetch) GetLatestRefundStatus(refundEndpointUrl string, HTTPClient *h
 	}
 
 	body, err := ioutil.ReadAll(res.Body)
-	log.Info("Refund response body", log.Data{keys.RefundDetails: string(body)})
 	if err != nil {
 		return &p, res.StatusCode, err
 	}
@@ -147,6 +146,7 @@ func (impl *Fetch) GetLatestRefundStatus(refundEndpointUrl string, HTTPClient *h
 	if err := json.Unmarshal(body, &p); err != nil {
 		return &p, res.StatusCode, err
 	}
+	log.Info("Refund response body", log.Data{keys.RefundDetails: p})
 
 	return &p, res.StatusCode, nil
 }

--- a/payment/payment_test.go
+++ b/payment/payment_test.go
@@ -53,6 +53,15 @@ const paymentDetailsTestData = `{
     "payment_status": "accepted"
 }`
 
+const refundStatusTestData = `{
+    "refund_id": "lp9o81j5pgo0efsscq86vsn7pn",
+    "refunded_at": "2019-07-12T12:26:32.786Z",
+    "created_at": "2019-07-12T12:26:32.786Z",
+    "amount": 100,
+    "status": "success",
+    "payment_external_refund_url": "http://test.url"
+}`
+
 func TestUnitGetPayment(t *testing.T) {
 
 	p := Fetch{}
@@ -120,6 +129,30 @@ func TestUnitGetDetailsPayment(t *testing.T) {
 			p.GetPaymentDetails("http://test-url.com",
 				testutil.CreateMockClient(false, 404, paymentDetailsTestData),
 				"")
+		So(err, ShouldNotBeNil)
+		So(statusCode, ShouldEqual, 404)
+	})
+}
+
+func TestUnitGetLatestRefundStatus(t *testing.T) {
+
+	p := Fetch{}
+
+	Convey("test successful get refund details ", t, func() {
+		b, statusCode, err := p.GetLatestRefundStatus("http://test-url.com", testutil.CreateMockClient(true, 200, refundStatusTestData), "")
+		So(err, ShouldBeNil)
+		So(statusCode, ShouldEqual, 200)
+		So(b, ShouldNotBeEmpty)
+	})
+
+	Convey("test error returned when client throws error", t, func() {
+		_, statusCode, err := p.GetLatestRefundStatus("test-url.com", testutil.CreateMockClient(false, 500, refundStatusTestData), "")
+		So(err, ShouldNotBeNil)
+		So(statusCode, ShouldEqual, 500)
+	})
+
+	Convey("test error returned when invalid http status returned", t, func() {
+		_, statusCode, err := p.GetLatestRefundStatus("http://test-url.com", testutil.CreateMockClient(false, 404, refundStatusTestData), "")
 		So(err, ShouldNotBeNil)
 		So(statusCode, ShouldEqual, 404)
 	})


### PR DESCRIPTION
Changed all string(body) to relevant object for Payment, PaymentDetails and RefundDetails keys.

Added TestUnitGetLatestRefundStatus to test that function.

Updated chs.go version to 1.2.8
