### PR TITLE
Add overseas product type for zip portal submissions

### DIFF
--- a/assets/product_code.yml
+++ b/assets/product_code.yml
@@ -32,3 +32,4 @@ product_code:
   ll-confirmation-statement: 15003
   certified-copy-digital: 25142
   certified-copy-incorporation-digital: 25143
+  overseas-package-accounts: 16400


### PR DESCRIPTION
Add product type for overseas account submissions from the Zip portal.
Related accounts-filing-api PR: https://github.com/companieshouse/accounts-filing-api/pull/108
Resolves: [AOAF-650](https://companieshouse.atlassian.net/browse/AOAF-650)


[AOAF-650]: https://companieshouse.atlassian.net/browse/AOAF-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ